### PR TITLE
Add web UI for knowledge base

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ A mem0-like memory system for GitHub Copilot that provides persistent knowledge 
 - 🔒 **Local Storage**: All data stored locally for corporate compliance
 - ⚡ **Fast Retrieval**: Sub-500ms search performance
 - 🎯 **GitHub Copilot Integration**: Designed specifically for Copilot workflows
+- 🌐 **Streamlit UI**: Web interface for searching and managing memories
 
 ## Memory Types
 
@@ -31,10 +32,11 @@ A mem0-like memory system for GitHub Copilot that provides persistent knowledge 
    pip install -r requirements.txt
    ```
 
-3. **Test the server**:
+3. **Start the server**:
    ```bash
    python kb_server.py
    ```
+   This also launches a Streamlit UI at [http://localhost:8501](http://localhost:8501) for managing memories.
 
 ## GitHub Copilot Integration
 
@@ -143,6 +145,7 @@ Delete a memory by ID.
 
 - `KB_DATA_DIR`: Directory for ChromaDB storage (default: `./kb_data`)
 - `KB_INITIAL_FILE`: Optional path to initial knowledge file to load on startup
+- `KB_UI_PORT`: Port for the Streamlit UI (default: `8501`)
 
 ### Initial Knowledge File
 

--- a/kb_server.py
+++ b/kb_server.py
@@ -10,6 +10,8 @@ import asyncio
 import json
 import os
 import re
+import subprocess
+import sys
 import uuid
 from datetime import datetime, timezone
 from pathlib import Path
@@ -33,6 +35,9 @@ KB_DATA_DIR = os.getenv("KB_DATA_DIR", "./kb_data")
 KB_INITIAL_FILE = os.getenv("KB_INITIAL_FILE", None)
 EMBEDDING_MODEL_NAME = "all-MiniLM-L6-v2"
 COLLECTION_NAME = "knowledge_base"
+KB_UI_PORT = os.getenv("KB_UI_PORT", "8501")
+
+ui_process: Optional[subprocess.Popen] = None
 
 
 def init_database():
@@ -75,6 +80,25 @@ def init_database():
     # Load initial knowledge file if specified
     if KB_INITIAL_FILE:
         load_initial_knowledge(KB_INITIAL_FILE)
+
+
+def start_ui() -> Optional[subprocess.Popen]:
+    """Launch the Streamlit UI in a separate process."""
+    ui_script = Path(__file__).with_name("kb_ui.py")
+    if not ui_script.exists():
+        return None
+    try:
+        proc = subprocess.Popen(
+            [sys.executable, "-m", "streamlit", "run", str(ui_script),
+             "--server.port", str(KB_UI_PORT), "--server.headless", "true"],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+        print(f"Streamlit UI available at http://localhost:{KB_UI_PORT}")
+        return proc
+    except FileNotFoundError:
+        print("Streamlit not installed; UI will not start.")
+        return None
 
 
 def load_initial_knowledge(file_path: str):
@@ -495,6 +519,10 @@ def main() -> None:
         # Initialize database
         init_database()
 
+        # Start the Streamlit UI in parallel
+        global ui_process
+        ui_process = start_ui()
+
         print("Knowledge Base MCP Server ready!")
         print("Running on stdio transport...")
 
@@ -506,6 +534,11 @@ def main() -> None:
     except Exception as e:
         print(f"Error starting server: {e}")
         raise
+    finally:
+        if ui_process:
+            ui_process.terminate()
+            ui_process.wait(timeout=5)
+            print("Streamlit UI stopped.")
 
 
 if __name__ == "__main__":

--- a/kb_ui.py
+++ b/kb_ui.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+"""Streamlit UI for managing the Knowledge Base."""
+
+import asyncio
+from pathlib import Path
+
+import streamlit as st
+
+from kb_server import (
+    init_database,
+    kb_save,
+    kb_search,
+    kb_list,
+    kb_delete,
+)
+
+# Initialize the database connection
+init_database()
+
+
+def run_async(coro):
+    """Utility to run async functions from Streamlit callbacks."""
+    return asyncio.run(coro)
+
+
+def main() -> None:
+    st.title("Knowledge Base MCP")
+    st.sidebar.markdown("## Actions")
+    action = st.sidebar.selectbox(
+        "Choose action",
+        ["Add Memory", "Search", "List Memories", "Delete Memory"],
+    )
+
+    if action == "Add Memory":
+        st.subheader("Add Memory")
+        content = st.text_area("Content")
+        memory_type = st.selectbox(
+            "Memory Type",
+            ["general", "environment", "code_snippet", "operational", "architectural"],
+        )
+        tags_str = st.text_input("Tags (comma separated)")
+        if st.button("Save"):
+            tags = [t.strip() for t in tags_str.split(",") if t.strip()] if tags_str else None
+            result = run_async(
+                kb_save(
+                    content=content,
+                    memory_type=memory_type if memory_type != "general" else None,
+                    tags=tags,
+                )
+            )
+            st.success(result)
+
+    elif action == "Search":
+        st.subheader("Search")
+        query = st.text_input("Query")
+        limit = st.number_input("Limit", min_value=1, max_value=20, value=5)
+        mtype = st.selectbox(
+            "Memory Type Filter",
+            ["", "environment", "code_snippet", "operational", "architectural"],
+        )
+        if st.button("Search"):
+            result = run_async(
+                kb_search(query=query, limit=int(limit), memory_type=mtype or None)
+            )
+            st.markdown(result)
+
+    elif action == "List Memories":
+        st.subheader("List Memories")
+        mtype = st.selectbox(
+            "Memory Type",
+            ["", "environment", "code_snippet", "operational", "architectural"],
+        )
+        limit = st.number_input("Limit", min_value=1, max_value=50, value=10)
+        include_content = st.checkbox("Include full content", value=False)
+        if st.button("List"):
+            result = run_async(
+                kb_list(
+                    memory_type=mtype or None,
+                    limit=int(limit),
+                    include_content=include_content,
+                )
+            )
+            st.markdown(result)
+
+    elif action == "Delete Memory":
+        st.subheader("Delete Memory")
+        mem_id = st.text_input("Memory ID (full or partial)")
+        if st.button("Delete"):
+            result = run_async(kb_delete(mem_id))
+            st.write(result)
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ python-dateutil>=2.8.2
 typing-extensions>=4.8.0
 pytest>=8.0.0
 pytest-asyncio>=0.23.0
+streamlit>=1.30.0


### PR DESCRIPTION
## Summary
- add a Streamlit UI for CRUD operations
- automatically start the UI alongside the MCP server
- document Streamlit usage and UI port variable
- include Streamlit dependency
- launch UI with `python -m streamlit`

## Testing
- `pip install -r requirements.txt`
- `pytest -q test_server.py`
- `pytest -q test_initial_knowledge.py`


------
https://chatgpt.com/codex/tasks/task_b_6879358757d8832185f2a793002f57f0